### PR TITLE
Fix: 模型配置动态加载不生效问题

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.40.0
+	golang.org/x/net v0.41.0
 	golang.org/x/text v0.27.0
 )
 
@@ -58,7 +59,6 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/claudecode/router.go
+++ b/internal/claudecode/router.go
@@ -280,3 +280,13 @@ func (r *ModelRouter) LogRoutingDecision(originalModel, routedModel, reason stri
 
 	r.logger.WithFields(fields).Info("Model routing decision")
 }
+
+// UpdateModelConfiguration updates the model configuration dynamically
+func (r *ModelRouter) UpdateModelConfiguration(bigModel, smallModel string) {
+	r.bigModel = bigModel
+	r.smallModel = smallModel
+	r.logger.WithFields(logrus.Fields{
+		"big_model":   bigModel,
+		"small_model": smallModel,
+	}).Info("Updated model router configuration")
+}

--- a/internal/handlers/enhanced_messages.go
+++ b/internal/handlers/enhanced_messages.go
@@ -114,6 +114,9 @@ func (h *EnhancedMessagesHandler) CreateMessage(c *gin.Context) {
 	}
 
 	// Apply intelligent model routing
+	// Update model router with current configuration
+	h.modelRouter.UpdateModelConfiguration(cfg.BigModel, cfg.SmallModel)
+
 	routedModel := h.modelRouter.RouteModel(&claudeReq)
 	if routedModel != claudeReq.Model {
 		h.logger.WithFields(logrus.Fields{


### PR DESCRIPTION
# Fix: 模型配置动态加载不生效问题

## 问题描述
用户在配置页面更新模型映射（如设置大模型为 `gemini-2.5-pro`）后，系统仍然使用启动时的旧配置进行模型路由，导致配置更新不生效。

## 根本原因
`EnhancedMessagesHandler` 中的 `modelRouter` 在初始化时创建，使用启动时的配置参数。即使用户后续更新了配置，模型路由器仍然保持着初始化时的配置。

## 解决方案
在每次请求处理时，使用最新的配置动态更新模型路由器，确保配置变更立即生效。

## 修改内容

### 1. 新增动态配置更新方法
在 `internal/claudecode/router.go` 中添加：
```go
func (r *ModelRouter) UpdateModelConfiguration(bigModel, smallModel string) {
    r.bigModel = bigModel
    r.smallModel = smallModel
    // ... 日志记录
}
```

### 2. 在请求处理时更新配置
在 `internal/handlers/enhanced_messages.go` 的 `CreateMessage` 方法中：
```go
// 在模型路由前更新配置
h.modelRouter.UpdateModelConfiguration(cfg.BigModel, cfg.SmallModel)
routedModel := h.modelRouter.RouteModel(&claudeReq)
```

## 测试验证
- ✅ 配置更新立即生效，无需重启应用
- ✅ 模型路由决策使用最新配置
- ✅ 日志正确显示路由结果

## 影响评估
- **兼容性**：完全向后兼容
- **性能**：每次请求增加一次配置更新操作，开销极小
- **功能**：修复用户配置不生效的问题

## 相关文件
- `internal/handlers/enhanced_messages.go`
- `internal/claudecode/router.go`

---

**修复前**：
```
{"level":"info","msg":"Applied model routing","original_model":"claude-3-5-sonnet-20241022","routed_model":"gpt-4o"}
```

**修复后**：
```
{"level":"info","msg":"Applied model routing","original_model":"claude-3-5-sonnet-20241022","routed_model":"gemini-2.5-pro"}
``` 